### PR TITLE
Add `repository` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "@shopify:registry": "https://registry.npmjs.org"
   },
   "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/restyle.git"
+  },
   "dependencies": {},
   "devDependencies": {
     "@types/jest": "^24.0.18",


### PR DESCRIPTION
The presence of this field allows developers, and tools such as Dependabot, to find the repository for the package.

Of particular value, Dependabot is able to expose Release Notes, Changelogs, and Commit Messages in its update PRs.