### PR TITLE
Implement shorthand syntax for spacing and backgroundColor

### DIFF
--- a/src/createBox.ts
+++ b/src/createBox.ts
@@ -39,7 +39,7 @@ export type BoxProps<
   PositionProps<Theme> &
   (EnableShorthand extends true
     ? SpacingShorthandProps<Theme> & BackgroundColorShorthandProps<Theme>
-    : never);
+    : Record<string, never>);
 
 export const boxRestyleFunctions = [
   backgroundColor,

--- a/src/createBox.ts
+++ b/src/createBox.ts
@@ -5,6 +5,7 @@ import createRestyleComponent from './createRestyleComponent';
 import {BaseTheme} from './types';
 import {
   backgroundColor,
+  backgroundColorShorthand,
   opacity,
   layout,
   spacing,
@@ -20,23 +21,34 @@ import {
   PositionProps,
   visible,
   VisibleProps,
+  SpacingShorthandProps,
+  BackgroundColorShorthandProps,
+  spacingShorthand,
 } from './restyleFunctions';
 
-export type BoxProps<Theme extends BaseTheme> = BackgroundColorProps<Theme> &
+export type BoxProps<
+  Theme extends BaseTheme,
+  EnableShorthand extends boolean = true
+> = BackgroundColorProps<Theme> &
   OpacityProps<Theme> &
   VisibleProps<Theme> &
   LayoutProps<Theme> &
   SpacingProps<Theme> &
   BorderProps<Theme> &
   ShadowProps<Theme> &
-  PositionProps<Theme>;
+  PositionProps<Theme> &
+  (EnableShorthand extends true
+    ? SpacingShorthandProps<Theme> & BackgroundColorShorthandProps<Theme>
+    : never);
 
 export const boxRestyleFunctions = [
   backgroundColor,
+  backgroundColorShorthand,
   opacity,
   visible,
   layout,
   spacing,
+  spacingShorthand,
   border,
   shadow,
   position,
@@ -44,12 +56,14 @@ export const boxRestyleFunctions = [
 
 const createBox = <
   Theme extends BaseTheme,
-  Props = React.ComponentProps<typeof View> & {children?: React.ReactNode}
+  Props = React.ComponentProps<typeof View> & {children?: React.ReactNode},
+  EnableShorthand extends boolean = true
 >(
   BaseComponent: React.ComponentType<any> = View,
 ) => {
   return createRestyleComponent<
-    BoxProps<Theme> & Omit<Props, keyof BoxProps<Theme>>,
+    BoxProps<Theme, EnableShorthand> &
+      Omit<Props, keyof BoxProps<Theme, EnableShorthand>>,
     Theme
   >(boxRestyleFunctions, BaseComponent);
 };

--- a/src/createRestyleFunction.ts
+++ b/src/createRestyleFunction.ts
@@ -2,8 +2,8 @@ import {
   ResponsiveValue,
   BaseTheme,
   Dimensions,
-  RNStyle,
   RestyleFunctionContainer,
+  RNStyleProperty,
 } from './types';
 import {getKeys} from './typeHelpers';
 
@@ -111,7 +111,7 @@ const createRestyleFunction = <
 }: {
   property: P;
   transform?: StyleTransformFunction<Theme, K, TProps[P]>;
-  styleProperty?: keyof RNStyle;
+  styleProperty?: RNStyleProperty;
   themeKey?: K;
 }): RestyleFunctionContainer<TProps, Theme, P, K> => {
   const styleProp = styleProperty || property.toString();

--- a/src/createText.ts
+++ b/src/createText.ts
@@ -16,16 +16,22 @@ import {
   TextShadowProps,
   TypographyProps,
   VisibleProps,
+  spacingShorthand,
+  SpacingShorthandProps,
 } from './restyleFunctions';
 import createVariant, {VariantProps} from './createVariant';
 
-export type TextProps<Theme extends BaseTheme> = ColorProps<Theme> &
+export type TextProps<
+  Theme extends BaseTheme,
+  EnableShorthand extends boolean = true
+> = ColorProps<Theme> &
   OpacityProps<Theme> &
   VisibleProps<Theme> &
   TypographyProps<Theme> &
   SpacingProps<Theme> &
   TextShadowProps<Theme> &
-  VariantProps<Theme, 'textVariants'>;
+  VariantProps<Theme, 'textVariants'> &
+  (EnableShorthand extends true ? SpacingShorthandProps<Theme> : never);
 
 export const textRestyleFunctions = [
   color,
@@ -33,18 +39,21 @@ export const textRestyleFunctions = [
   visible,
   typography,
   spacing,
+  spacingShorthand,
   textShadow,
   createVariant({themeKey: 'textVariants'}),
 ];
 
 const createText = <
   Theme extends BaseTheme,
-  Props = React.ComponentProps<typeof Text> & {children?: React.ReactNode}
+  Props = React.ComponentProps<typeof Text> & {children?: React.ReactNode},
+  EnableShorthand extends boolean = true
 >(
   BaseComponent: React.ComponentType<any> = Text,
 ) => {
   return createRestyleComponent<
-    TextProps<Theme> & Omit<Props, keyof TextProps<Theme>>,
+    TextProps<Theme, EnableShorthand> &
+      Omit<Props, keyof TextProps<Theme, EnableShorthand>>,
     Theme
   >(textRestyleFunctions, BaseComponent);
 };

--- a/src/restyleFunctions.ts
+++ b/src/restyleFunctions.ts
@@ -19,6 +19,20 @@ const spacingProperties = {
   paddingLeft: true,
   paddingHorizontal: true,
   paddingVertical: true,
+  m: 'margin',
+  mt: 'marginTop',
+  mr: 'marginRight',
+  mb: 'marginBottom',
+  ml: 'marginLeft',
+  mx: 'marginHorizontal',
+  my: 'marginVertical',
+  p: 'padding',
+  pt: 'paddingTop',
+  pr: 'paddingRight',
+  pb: 'paddingBottom',
+  pl: 'paddingLeft',
+  px: 'paddingHorizontal',
+  py: 'paddingVertical',
 };
 
 const typographyProperties = {
@@ -121,8 +135,11 @@ export const visible = createRestyleFunction({
 });
 
 export const spacing = getKeys(spacingProperties).map(property => {
+  const alias = spacingProperties[property];
+
   return createRestyleFunction({
     property,
+    styleProperty: typeof alias === 'string' ? alias : undefined,
     themeKey: 'spacing',
   });
 });
@@ -196,9 +213,9 @@ export const textShadow = [
 ];
 
 export const all = [
-  backgroundColor,
   color,
   opacity,
+  backgroundColor,
   ...spacing,
   ...typography,
   ...layout,
@@ -208,9 +225,6 @@ export const all = [
   ...textShadow,
 ];
 
-export interface BackgroundColorProps<Theme extends BaseTheme> {
-  backgroundColor?: ResponsiveValue<keyof Theme['colors'], Theme>;
-}
 export interface ColorProps<Theme extends BaseTheme> {
   color?: ResponsiveValue<keyof Theme['colors'], Theme>;
 }
@@ -220,6 +234,10 @@ export interface OpacityProps<Theme extends BaseTheme> {
 
 export interface VisibleProps<Theme extends BaseTheme> {
   visible?: ResponsiveValue<boolean, Theme>;
+}
+
+export interface BackgroundColorProps<Theme extends BaseTheme> {
+  backgroundColor?: ResponsiveValue<keyof Theme['colors'], Theme>;
 }
 
 export type SpacingProps<Theme extends BaseTheme> = {

--- a/src/restyleFunctions.ts
+++ b/src/restyleFunctions.ts
@@ -344,9 +344,11 @@ export type TextShadowProps<Theme extends BaseTheme> = {
 };
 
 export type AllProps<Theme extends BaseTheme> = BackgroundColorProps<Theme> &
+  BackgroundColorShorthandProps<Theme> &
   ColorProps<Theme> &
   OpacityProps<Theme> &
   SpacingProps<Theme> &
+  SpacingShorthandProps<Theme> &
   TypographyProps<Theme> &
   LayoutProps<Theme> &
   PositionProps<Theme> &

--- a/src/restyleFunctions.ts
+++ b/src/restyleFunctions.ts
@@ -1,7 +1,7 @@
 import {TextStyle, FlexStyle, ViewStyle} from 'react-native';
 
 import createRestyleFunction from './createRestyleFunction';
-import {BaseTheme, ResponsiveValue} from './types';
+import {BaseTheme, ResponsiveValue, RNStyleProperty} from './types';
 import {getKeys} from './typeHelpers';
 
 const spacingProperties = {
@@ -152,7 +152,9 @@ export const spacing = getKeys(spacingProperties).map(property => {
 
 export const spacingShorthand = getKeys(spacingPropertiesShorthand).map(
   property => {
-    const styleProperty = spacingPropertiesShorthand[property];
+    const styleProperty = spacingPropertiesShorthand[
+      property
+    ] as RNStyleProperty;
 
     return createRestyleFunction({
       property,

--- a/src/restyleFunctions.ts
+++ b/src/restyleFunctions.ts
@@ -19,6 +19,9 @@ const spacingProperties = {
   paddingLeft: true,
   paddingHorizontal: true,
   paddingVertical: true,
+};
+
+const spacingPropertiesShorthand = {
   m: 'margin',
   mt: 'marginTop',
   mr: 'marginRight',
@@ -119,6 +122,12 @@ export const backgroundColor = createRestyleFunction({
   themeKey: 'colors',
 });
 
+export const backgroundColorShorthand = createRestyleFunction({
+  property: 'bg',
+  styleProperty: 'backgroundColor',
+  themeKey: 'colors',
+});
+
 export const color = createRestyleFunction({
   property: 'color',
   themeKey: 'colors',
@@ -135,14 +144,23 @@ export const visible = createRestyleFunction({
 });
 
 export const spacing = getKeys(spacingProperties).map(property => {
-  const alias = spacingProperties[property];
-
   return createRestyleFunction({
     property,
-    styleProperty: typeof alias === 'string' ? alias : undefined,
     themeKey: 'spacing',
   });
 });
+
+export const spacingShorthand = getKeys(spacingPropertiesShorthand).map(
+  property => {
+    const styleProperty = spacingPropertiesShorthand[property];
+
+    return createRestyleFunction({
+      property,
+      styleProperty,
+      themeKey: 'spacing',
+    });
+  },
+);
 
 export const typography = getKeys(typographyProperties).map(property => {
   return createRestyleFunction({
@@ -216,7 +234,9 @@ export const all = [
   color,
   opacity,
   backgroundColor,
+  backgroundColorShorthand,
   ...spacing,
+  ...spacingShorthand,
   ...typography,
   ...layout,
   ...position,
@@ -240,8 +260,19 @@ export interface BackgroundColorProps<Theme extends BaseTheme> {
   backgroundColor?: ResponsiveValue<keyof Theme['colors'], Theme>;
 }
 
+export interface BackgroundColorShorthandProps<Theme extends BaseTheme> {
+  bg?: ResponsiveValue<keyof Theme['colors'], Theme>;
+}
+
 export type SpacingProps<Theme extends BaseTheme> = {
   [Key in keyof typeof spacingProperties]?: ResponsiveValue<
+    keyof Theme['spacing'],
+    Theme
+  >;
+};
+
+export type SpacingShorthandProps<Theme extends BaseTheme> = {
+  [Key in keyof typeof spacingPropertiesShorthand]?: ResponsiveValue<
     keyof Theme['spacing'],
     Theme
   >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,3 +52,7 @@ export type RestyleFunction<
 };
 
 export type RNStyle = ViewStyle | TextStyle | ImageStyle;
+export type RNStyleProperty =
+  | keyof ViewStyle
+  | keyof TextStyle
+  | keyof ImageStyle;


### PR DESCRIPTION
Its much nicer/cleaner to write out the spacing props in shorthand. This syntax is used in many similar projects that follow the system-ui spec.