### PR TITLE
useResponsiveProp hook to deconstruct responsive prop values

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,62 @@ const theme = createTheme({
 <Box flexDirection={{phone: 'column', tablet: 'row'}} />
 ```
 
+
+If you need to extract the value of a responsive prop in a custom component (e.g. to use it outside of component styles), you can use the `useResponsiveProp` hook:
+
+```tsx
+import {
+  ColorProps,
+  createBox,
+  useResponsiveProp,
+  useTheme,
+} from '@shopify/restyle';
+import React from 'react';
+import { ActivityIndicator, TouchableOpacity, TouchableOpacityProps } from 'react-native';
+
+import Text from './Text';
+import { Theme } from './theme';
+
+const BaseButton = createBox<Theme, TouchableOpacityProps>(TouchableOpacity);
+
+type Props = React.ComponentProps<typeof BaseButton> &
+  ColorProps<Theme> & {
+    label: string;
+    isLoading?: boolean;
+  };
+
+const Button = ({
+  label,
+  isLoading,
+  color = { phone: 'purple', tablet: 'blue' },
+  ...props
+}: Props) => {
+  const theme = useTheme<Theme>();
+
+  // Will be 'purple' on phone and 'blue' on tablet
+  const textColorProp = useResponsiveProp(color);
+
+  // Can safely perform logic with the extracted value
+  const bgColor = textColorProp === 'purple' ? 'lightPurple' : 'lightBlue';
+
+  return (
+    <BaseButton flexDirection="row" backgroundColor={bgColor} {...props}>
+      <Text
+        variant="buttonLabel"
+        color={color}
+        marginRight={isLoading ? 's' : undefined}
+      >
+        {label}
+      </Text>
+      {isLoading ? (
+        <ActivityIndicator color={theme.colors[textColorProp]} />
+      ) : null}
+    </BaseButton>
+  );
+};
+
+```
+
 ### Overriding Styles
 
 Any Restyle component also accepts a regular `style` property and will apply it after all other styles, which means that you can use this to do any overrides that you might find necessary.

--- a/src/createRestyleFunction.ts
+++ b/src/createRestyleFunction.ts
@@ -1,102 +1,5 @@
-import {
-  ResponsiveValue,
-  BaseTheme,
-  Dimensions,
-  RestyleFunctionContainer,
-  RNStyleProperty,
-} from './types';
-import {getKeys} from './typeHelpers';
-
-type PropValue = string | number | undefined | null;
-
-type StyleTransformFunction<
-  Theme extends BaseTheme,
-  K extends keyof Theme | undefined,
-  TVal
-> = (params: {value: TVal | null; theme: Theme; themeKey?: K}) => TVal | null;
-
-const getValueForScreenSize = <Theme extends BaseTheme, TVal>({
-  responsiveValue,
-  breakpoints,
-  dimensions,
-}: {
-  responsiveValue: {[key in keyof Theme['breakpoints']]?: TVal};
-  breakpoints: Theme['breakpoints'];
-  dimensions: Dimensions;
-}): TVal | null => {
-  const sortedBreakpoints = Object.entries(breakpoints).sort((valA, valB) => {
-    return valA[1] - valB[1];
-  });
-  const {width} = dimensions;
-  return sortedBreakpoints.reduce<TVal | null>(
-    (acc, [breakpoint, minWidth]) => {
-      if (width >= minWidth && responsiveValue[breakpoint] !== undefined)
-        return responsiveValue[breakpoint] as TVal;
-      return acc;
-    },
-    null,
-  );
-};
-
-const isResponsiveObjectValue = <Theme extends BaseTheme, TVal>(
-  val: ResponsiveValue<TVal, Theme>,
-  theme: Theme,
-): val is {[Key in keyof Theme['breakpoints']]?: TVal} => {
-  if (!val) return false;
-  if (typeof val !== 'object') return false;
-  return getKeys(val).reduce((acc: boolean, key) => {
-    return acc && theme.breakpoints[key as string] !== undefined;
-  }, true);
-};
-
-type ValueOf<T> = T[keyof T];
-
-function isThemeKey<Theme extends BaseTheme>(
-  theme: Theme,
-  K: keyof Theme | undefined,
-): K is keyof Theme {
-  return theme[K as keyof Theme];
-}
-
-const getValue = <
-  TVal extends PropValue,
-  Theme extends BaseTheme,
-  K extends keyof Theme | undefined
->(
-  propValue: ResponsiveValue<TVal, Theme>,
-  {
-    theme,
-    transform,
-    dimensions,
-    themeKey,
-  }: {
-    theme: Theme;
-    transform?: StyleTransformFunction<Theme, K, TVal>;
-    dimensions: Dimensions;
-    themeKey?: K;
-  },
-):
-  | TVal
-  | (K extends keyof Theme ? ValueOf<Theme[K]> : never)
-  | null
-  | undefined => {
-  const val = isResponsiveObjectValue(propValue, theme)
-    ? getValueForScreenSize({
-        responsiveValue: propValue,
-        breakpoints: theme.breakpoints,
-        dimensions,
-      })
-    : propValue;
-  if (transform) return transform({value: val, theme, themeKey});
-  if (isThemeKey(theme, themeKey)) {
-    if (val && theme[themeKey][val as string] === undefined)
-      throw new Error(`Value '${val}' does not exist in theme['${themeKey}']`);
-
-    return val ? theme[themeKey][val as string] : val;
-  }
-
-  return val;
-};
+import {BaseTheme, RestyleFunctionContainer, RNStyleProperty} from './types';
+import {getResponsiveValue, StyleTransformFunction} from './responsiveHelpers';
 
 const createRestyleFunction = <
   Theme extends BaseTheme = BaseTheme,
@@ -121,7 +24,7 @@ const createRestyleFunction = <
     themeKey,
     variant: false,
     func: (props, {theme, dimensions}) => {
-      const value = getValue(props[property], {
+      const value = getResponsiveValue(props[property], {
         theme,
         dimensions,
         themeKey,

--- a/src/hooks/useResponsiveProp.ts
+++ b/src/hooks/useResponsiveProp.ts
@@ -1,0 +1,25 @@
+import {BaseTheme, PropValue, ResponsiveValue} from '../types';
+import {
+  getValueForScreenSize,
+  isResponsiveObjectValue,
+} from '../responsiveHelpers';
+
+import useDimensions from './useDimensions';
+import useTheme from './useTheme';
+
+const useResponsiveProp = <Theme extends BaseTheme, TVal extends PropValue>(
+  propValue: ResponsiveValue<TVal, Theme>,
+) => {
+  const theme = useTheme<Theme>();
+  const dimensions = useDimensions();
+
+  return isResponsiveObjectValue(propValue, theme)
+    ? getValueForScreenSize({
+        responsiveValue: propValue,
+        breakpoints: theme.breakpoints,
+        dimensions,
+      })
+    : propValue;
+};
+
+export default useResponsiveProp;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {default as createText} from './createText';
 export {ThemeProvider} from './context';
 export {default as useTheme} from './hooks/useTheme';
 export {default as useRestyle} from './hooks/useRestyle';
+export {default as useResponsiveProp} from './hooks/useResponsiveProp';
 export {default as createTheme} from './createTheme';
 export {default as createRestyleFunction} from './createRestyleFunction';
 export {default as createRestyleComponent} from './createRestyleComponent';

--- a/src/responsiveHelpers.ts
+++ b/src/responsiveHelpers.ts
@@ -1,0 +1,95 @@
+import {BaseTheme, Dimensions, PropValue, ResponsiveValue} from './types';
+import {getKeys} from './typeHelpers';
+
+export type StyleTransformFunction<
+  Theme extends BaseTheme,
+  K extends keyof Theme | undefined,
+  TVal
+> = (params: {
+  value: TVal | undefined | null;
+  theme: Theme;
+  themeKey?: K;
+}) => TVal | undefined | null;
+
+type ValueOf<T> = T[keyof T];
+
+function isThemeKey<Theme extends BaseTheme>(
+  theme: Theme,
+  K: keyof Theme | undefined,
+): K is keyof Theme {
+  return theme[K as keyof Theme];
+}
+
+export const getValueForScreenSize = <Theme extends BaseTheme, TVal>({
+  responsiveValue,
+  breakpoints,
+  dimensions,
+}: {
+  responsiveValue: {[key in keyof Theme['breakpoints']]?: TVal};
+  breakpoints: Theme['breakpoints'];
+  dimensions: Dimensions;
+}): TVal | undefined => {
+  const sortedBreakpoints = Object.entries(breakpoints).sort((valA, valB) => {
+    return valA[1] - valB[1];
+  });
+  const {width} = dimensions;
+  return sortedBreakpoints.reduce<TVal | undefined>(
+    (acc, [breakpoint, minWidth]) => {
+      if (width >= minWidth && responsiveValue[breakpoint] !== undefined)
+        return responsiveValue[breakpoint] as TVal;
+      return acc;
+    },
+    undefined,
+  );
+};
+
+export const isResponsiveObjectValue = <Theme extends BaseTheme, TVal>(
+  val: ResponsiveValue<TVal, Theme>,
+  theme: Theme,
+): val is {[Key in keyof Theme['breakpoints']]?: TVal} => {
+  if (!val) return false;
+  if (typeof val !== 'object') return false;
+  return getKeys(val).reduce((acc: boolean, key) => {
+    return acc && theme.breakpoints[key as string] !== undefined;
+  }, true);
+};
+
+export const getResponsiveValue = <
+  TVal extends PropValue,
+  Theme extends BaseTheme,
+  K extends keyof Theme | undefined
+>(
+  propValue: ResponsiveValue<TVal, Theme>,
+  {
+    theme,
+    transform,
+    dimensions,
+    themeKey,
+  }: {
+    theme: Theme;
+    transform?: StyleTransformFunction<Theme, K, TVal>;
+    dimensions: Dimensions;
+    themeKey?: K;
+  },
+):
+  | TVal
+  | (K extends keyof Theme ? ValueOf<Theme[K]> : never)
+  | null
+  | undefined => {
+  const val = isResponsiveObjectValue(propValue, theme)
+    ? getValueForScreenSize({
+        responsiveValue: propValue,
+        breakpoints: theme.breakpoints,
+        dimensions,
+      })
+    : propValue;
+  if (transform) return transform({value: val, theme, themeKey});
+  if (isThemeKey(theme, themeKey)) {
+    if (val && theme[themeKey][val as string] === undefined)
+      throw new Error(`Value '${val}' does not exist in theme['${themeKey}']`);
+
+    return val ? theme[themeKey][val as string] : val;
+  }
+
+  return val;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,10 @@ export type RestyleFunction<
 };
 
 export type RNStyle = ViewStyle | TextStyle | ImageStyle;
+
 export type RNStyleProperty =
   | keyof ViewStyle
   | keyof TextStyle
   | keyof ImageStyle;
+
+export type PropValue = string | number | undefined | null;


### PR DESCRIPTION
Sets up a helper that handles transforming a prop that might have responsive values into the appropriate value based on the current screen dimensions. Useful when you need to extract the actual prop and use it outside of style objects (e.g. colours for Activity indicator, conditional logic on prop values, etc)

This PR builds on #21, so that will need to be merged first