### PR TITLE
Use less strict prop types for restyleFunctions passed to useRestyle

### DIFF
--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -3,7 +3,6 @@ import {StyleProp} from 'react-native';
 
 import {BaseTheme, RestyleFunctionContainer, RNStyle} from '../types';
 import composeRestyleFunctions from '../composeRestyleFunctions';
-import {AllProps} from '../restyleFunctions';
 import {getKeys} from '../typeHelpers';
 
 import useDimensions from './useDimensions';
@@ -32,7 +31,7 @@ const filterRestyleProps = <
 
 const useRestyle = <
   Theme extends BaseTheme,
-  TRestyleProps extends AllProps<Theme>,
+  TRestyleProps extends Record<string, any>,
   TProps extends TRestyleProps & {style?: StyleProp<RNStyle>}
 >(
   restyleFunctions: (


### PR DESCRIPTION
Fixes #34. We can't allow `useRestyle` to only accept `restyleFunctions` with props of type `AllProps` since `createVariant` can be configured to accept a prop of any name as its input. 