### PR TITLE
Add variant does not exist error message

### DIFF
--- a/src/createVariant.ts
+++ b/src/createVariant.ts
@@ -51,6 +51,12 @@ function createVariant<
       property
     ];
 
+    if (theme[themeKey] === undefined) {
+      throw new Error(
+        `Variant ${themeKey} does not exist in the current theme`,
+      );
+    }
+
     const variantDefaults = theme[themeKey].defaults as Partial<
       AllProps<Theme>
     >;


### PR DESCRIPTION
Currently, if you create a component using the `createText` function and your theme doesn't have a `textVariants` key, a confusing error is thrown:
`TypeError: undefined is not an object (evaluating 'theme[themeKey].defaults')`

What this PR does is to attempt to fix that by throwing an exception if there isn't such key in the current theme, with a more descriptive error message.