### PR TITLE
Improve rendering performance by removing unnecessary uses of the spread operator

### DIFF
--- a/src/composeRestyleFunctions.ts
+++ b/src/composeRestyleFunctions.ts
@@ -45,7 +45,7 @@ const composeRestyleFunctions = <
     },
   ): RNStyle => {
     return funcs.reduce((acc, func) => {
-      return {...acc, ...func(props, {theme, dimensions})};
+      return Object.assign(acc, func(props, {theme, dimensions}));
     }, {});
   };
   return {

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -16,16 +16,21 @@ const filterRestyleProps = <
   omitList: (keyof TRestyleProps)[],
 ): Omit<TProps, keyof TRestyleProps> => {
   const omittedProp = omitList.reduce<Record<keyof TRestyleProps, boolean>>(
-    (acc, prop) => ({...acc, [prop]: true}),
+    (acc, prop) => {
+      acc[prop] = true;
+      return acc;
+    },
     {} as Record<keyof TRestyleProps, boolean>,
   );
 
   return getKeys(props).reduce(
     (acc, key) => {
-      if (omittedProp[key as keyof TRestyleProps]) return acc;
-      return {...acc, [key]: props[key]};
+      if (!omittedProp[key as keyof TRestyleProps]) {
+        acc[key] = props[key];
+      }
+      return acc;
     },
-    {} as Omit<TProps, keyof TRestyleProps>,
+    {} as TProps,
   );
 };
 
@@ -54,10 +59,8 @@ const useRestyle = <
     composedRestyleFunction.properties,
   );
 
-  return {
-    ...cleanProps,
-    style: [style, props.style].filter(Boolean),
-  };
+  (cleanProps as TProps).style = [style, props.style].filter(Boolean);
+  return cleanProps;
 };
 
 export default useRestyle;


### PR DESCRIPTION
Found some cheap performance wins by removing unnecessary uses of the spread operator. Here's the results when testing this on the following component: 

```tsx
import React from 'react'
import {times} from 'lodash'
import {Box, Text} from './components'

export const Test = () => {
  return times(100, i => {
    return (
      <Box key={i}>
        <Text>Text #{i}</Text>
      </Box>
    )
  })
}
```

![image](https://user-images.githubusercontent.com/688415/97019321-79cd5980-1550-11eb-985e-3106c2acf8b8.png)
*(Image to the left is current version of Restyle, right one is with the changes of this PR)*

For comparison, here's the above component rendering with just regular React Native Text and View components:

![image](https://user-images.githubusercontent.com/688415/97019489-ad0fe880-1550-11eb-8f1a-7e78b869d380.png)

There are likely more things that can be improved on further to reach results closer to the image above. 