### PR TITLE
Allow creation of `textVariant` without theme key & strengthen `createVariant` types

### DIFF
--- a/src/createVariant.ts
+++ b/src/createVariant.ts
@@ -52,15 +52,9 @@ function createVariant<
       property
     ];
 
-    if (theme[themeKey] === undefined) {
-      throw new Error(
-        `Variant ${themeKey} does not exist in the current theme`,
-      );
-    }
-
-    const variantDefaults = theme[themeKey].defaults as Partial<
-      AllProps<Theme>
-    >;
+    const variantDefaults = theme[themeKey]
+      ? (theme[themeKey].defaults as Partial<AllProps<Theme>>)
+      : {};
 
     if (!expandedProps && !defaults && !variantDefaults) return {};
     return allRestyleFunctions.buildStyle(

--- a/src/createVariant.ts
+++ b/src/createVariant.ts
@@ -3,6 +3,7 @@ import {
   ResponsiveValue,
   RestyleFunctionContainer,
   RestyleFunction,
+  SafeVariants,
 } from './types';
 import createRestyleFunction from './createRestyleFunction';
 import {all, AllProps} from './restyleFunctions';
@@ -13,7 +14,7 @@ const allRestyleFunctions = composeRestyleFunctions(all);
 // With Custom Prop Name
 function createVariant<
   Theme extends BaseTheme,
-  K extends keyof Theme = keyof Theme,
+  K extends keyof SafeVariants<Theme> = keyof SafeVariants<Theme>,
   P extends keyof any = keyof any
 >(params: {
   property: P;
@@ -23,14 +24,14 @@ function createVariant<
 // Without Custom Prop Name
 function createVariant<
   Theme extends BaseTheme,
-  K extends keyof Theme = keyof Theme
+  K extends keyof SafeVariants<Theme> = keyof SafeVariants<Theme>
 >(params: {
   themeKey: K;
   defaults?: AllProps<Theme>;
 }): RestyleFunctionContainer<VariantProps<Theme, K>, Theme, 'variant', K>;
 function createVariant<
   Theme extends BaseTheme,
-  K extends keyof Theme,
+  K extends keyof SafeVariants<Theme>,
   P extends keyof any,
   TProps extends VariantProps<Theme, K, P>
 >({

--- a/src/test/createVariant.test.ts
+++ b/src/test/createVariant.test.ts
@@ -152,6 +152,20 @@ describe('createVariant', () => {
     });
   });
 
+  it('correctly creates textVariants without key in theme', () => {
+    const themeSubset = {...theme};
+    delete themeSubset.textVariants;
+    const variant = createVariant({themeKey: 'textVariants'});
+    expect(variant.func({}, {theme: themeSubset, dimensions})).toStrictEqual(
+      {},
+    );
+  });
+
+  it('correctly creates an unknown variant without key in theme', () => {
+    const variant = createVariant({themeKey: '__variant__'});
+    expect(variant.func({}, {theme, dimensions})).toStrictEqual({});
+  });
+
   it('supports referencing other theme values in the variant', () => {
     const variant = createVariant({themeKey: 'textVariants'});
     expect(

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,9 @@ export type ResponsiveValue<Value, Theme extends BaseTheme> =
   | Value
   | {[Key in keyof Theme['breakpoints']]?: Value};
 
-export interface BaseTheme {
+export type SafeVariants<T> = Omit<T, keyof KnownBaseTheme>;
+
+export interface KnownBaseTheme {
   colors: {
     [key: string]: string;
   };
@@ -20,6 +22,9 @@ export interface BaseTheme {
   borderRadii?: {
     [key: string]: number;
   };
+}
+
+export interface BaseTheme extends KnownBaseTheme {
   [key: string]: any;
 }
 


### PR DESCRIPTION
**Problem**
Recently [this PR](https://github.com/Shopify/restyle/pull/59) fixed an issue with `undefined` keys in the theme by adding an error message. However this doesn't take into account that all of the documentation and typing is such that you shouldn't need a `textVariant` key in the theme in order to run `createText`.

**Solution**
Instead of updating all of the documentation and typing, we remove this error and just ensure we check if the key exists before attempting to access the default values [added here](https://github.com/Shopify/restyle/pull/51). Tests have also been added to cover this scenario.

--
Typing has also been strengthened on `createVariant`'s `themeKey` prop to remove being able to create a variant with the existing base theme keys of  `colors, spacing, breakpoints, zIndices, borderRadii`.

