### PR TITLE
add textDecorationColor to typographyProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ The Restyle library comes with a number of predefined Restyle functions for your
 | shadow           | shadowColor                                                                                                                                                                                         | colors      |
 | textShadow       | textShadowOffset, textShadowRadius                                                                                                                                                                  | _none_      |
 | textShadow       | textShadowColor                                                                                                                                                                                     | colors      |
+| textDecorationColor       | textDecorationColor                                                                                                                                                                                     | colors      |
 | typography       | fontFamily, fontSize, fontStyle, fontWeight, letterSpacing, lineHeight, textAlign, textDecorationLine, textDecorationStyle, textTransform                                                           | _none_      |
 
 #### Custom Restyle Functions

--- a/src/restyleFunctions.ts
+++ b/src/restyleFunctions.ts
@@ -56,6 +56,7 @@ const typographyProperties = {
   textAlign: true,
   textDecorationLine: true,
   textDecorationStyle: true,
+  textDecorationColor: true,
   textTransform: true,
 };
 


### PR DESCRIPTION
Seems like `textDecorationColor` is not supported, it's a one-line fix that maps it to colors. 

PS. We've been using this library at work and the whole team loves it at [@haystackapp](https://github.com/haystackapp)! 👏 