### PR TITLE
Fix ts error for useRestyle hook

### DIFF
--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -40,8 +40,8 @@ const useRestyle = <
   TProps extends TRestyleProps & {style?: StyleProp<RNStyle>}
 >(
   restyleFunctions: (
-    | RestyleFunctionContainer<TRestyleProps, Theme>
-    | RestyleFunctionContainer<TRestyleProps, Theme>[])[],
+    | RestyleFunctionContainer<TProps, Theme>
+    | RestyleFunctionContainer<TProps, Theme>[])[],
   props: TProps,
 ) => {
   const theme = useTheme<Theme>();

--- a/src/test/useRestyle.test.tsx
+++ b/src/test/useRestyle.test.tsx
@@ -1,0 +1,42 @@
+import React, {ComponentPropsWithoutRef} from 'react';
+import {Text, TouchableOpacity} from 'react-native';
+
+import useRestyle from '../hooks/useRestyle';
+import {position, PositionProps} from '../restyleFunctions';
+import createVariant, {VariantProps} from '../createVariant';
+
+const theme = {
+  colors: {},
+  spacing: {},
+  buttonVariants: {
+    defaults: {},
+  },
+  breakpoints: {
+    phone: 0,
+    tablet: 376,
+  },
+};
+type Theme = typeof theme;
+
+type Props = VariantProps<Theme, 'buttonVariants'> &
+  PositionProps<Theme> & {
+    title: string;
+  } & ComponentPropsWithoutRef<typeof TouchableOpacity>;
+
+const restyleFunctions = [
+  position,
+  createVariant({themeKey: 'buttonVariants'}),
+];
+
+function Button({title, ...rest}: Props) {
+  const props = useRestyle(restyleFunctions, rest);
+  return (
+    <TouchableOpacity {...props}>
+      <Text>{title}</Text>
+    </TouchableOpacity>
+  );
+}
+
+function Screen() {
+  return <Button title="test" position="absolute" />;
+}


### PR DESCRIPTION
This fixes the TypeScript when useRestyle is used together with a
variant and other restyle functions.

To test it out, undo the changes in `useRestyle.ts`. The example test (which should be deleted before a merge, I guess) should contain a TypeScript error regarding the `useRestyle` hook usage. When you reapply the changes from this commit, the error should be gone.

I ran the linter (also with the exclude for the test directory removed in tsconfig.json) and didn't see any breakage after the changes of `useRestyle.ts`.