### PR TITLE
feat: Improve web support with StyleSheet when creating styles

### DIFF
--- a/src/composeRestyleFunctions.ts
+++ b/src/composeRestyleFunctions.ts
@@ -1,3 +1,5 @@
+import {StyleSheet} from 'react-native';
+
 import {
   RestyleFunctionContainer,
   BaseTheme,
@@ -44,9 +46,11 @@ const composeRestyleFunctions = <
       dimensions: Dimensions;
     },
   ): RNStyle => {
-    return funcs.reduce((acc, func) => {
+    const styles = funcs.reduce((acc, func) => {
       return Object.assign(acc, func(props, {theme, dimensions}));
     }, {});
+    const {stylesheet} = StyleSheet.create({stylesheet: styles});
+    return stylesheet;
   };
   return {
     buildStyle,


### PR DESCRIPTION
### Goals
The idea of this PR is to improve web support using StyleSheet when styles are built.

Basically trying to address [this comment](https://github.com/Shopify/restyle/issues/20#issuecomment-661098754).

### Implementation:
Use StyleSheet.create inside composeRestyleFunctions.buildStyle().

### Tests: 
Existing tests passed without any modifications.

I also tested a build on another project:

- Deps: react-native-web ^0.13.3 and react-native ^0.63.0, works fine on both web and native;

- Inline styles on the web are gone, now react-native-web is applying CSS classes as expected;
