### PR TITLE
quickly copy/paste installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ const App = () => {
 ## Installation
 ### Yarn
 ```bash
-$ yarn add @shopify/restyle
+yarn add @shopify/restyle
 ```
 ### NPM
 ```bash
-$ npm install @shopify/restyle
+npm install @shopify/restyle
 ```
 
 ## Usage


### PR DESCRIPTION
*Motivation:*
I want to quickly install the lib, and GitHub added a clipboard icon:
![image](https://user-images.githubusercontent.com/360936/122834662-46b1b480-d2ef-11eb-81af-f05faba0405c.png)

When you use it, your clipboard copy this:
```
$ yarn add @shopify/restyle
```
It doesn't spark joy on your terminal when you paste it 😅

![image](https://user-images.githubusercontent.com/360936/122834754-6ea11800-d2ef-11eb-9dd8-37a6979d7483.png)
