### PR TITLE
Fix removeEventListener warning in rn0.65

### DIFF
--- a/src/hooks/useDimensions.ts
+++ b/src/hooks/useDimensions.ts
@@ -13,9 +13,13 @@ const useDimensions = () => {
   };
 
   useEffect(() => {
-    Dimensions.addEventListener('change', onChange);
+    const subscription = Dimensions.addEventListener('change', onChange) as any;
 
-    return () => Dimensions.removeEventListener('change', onChange);
+    return () =>
+      // Using removeEventListener is deprecated in react-native > 0.65 and will throw warning. Use .remove() if available.
+      subscription && subscription.remove
+        ? subscription.remove()
+        : Dimensions.removeEventListener('change', onChange);
   }, []);
 
   return dimensions;


### PR DESCRIPTION
Using `removeEventListener` is deprecated in [React-native >= 0.65](https://reactnative.dev/docs/appstate#removeeventlistener) and will throw warning as stated in issue #107.

This updated the `useDimensions` hook to call `.remove()` that is returned from `Dimensions.addEventListener` if that is available and fallback to using `Dimensions.removeEventListener`.