### PR TITLE
feat: Improve rendering performance on breakpoint changes and re-renders

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {BaseTheme} from 'types';
+import { DimensionsProvider } from './hooks/useDimensions'
 
 export const ThemeContext = React.createContext({
   colors: {},
@@ -13,4 +14,10 @@ export const ThemeProvider = ({
 }: {
   theme: BaseTheme;
   children: React.ReactNode;
-}) => <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
+}) => (
+  <ThemeContext.Provider value={theme}>
+    <DimensionsProvider>
+      {children}
+    </DimensionsProvider>
+  </ThemeContext.Provider>
+)

--- a/src/hooks/useDimensions.tsx
+++ b/src/hooks/useDimensions.tsx
@@ -1,9 +1,18 @@
-import {useState, useEffect} from 'react';
+import React, {useState, useEffect, useContext} from 'react';
 import {Dimensions} from 'react-native';
 
 import {Dimensions as DimensionsType} from '../types';
 
-const useDimensions = () => {
+const DimensionsContext = React.createContext<DimensionsType>({
+  width: 0,
+  height: 0,
+})
+
+export const DimensionsProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
   const [dimensions, setDimensions] = useState<DimensionsType>(
     Dimensions.get('window'),
   );
@@ -22,7 +31,13 @@ const useDimensions = () => {
         : Dimensions.removeEventListener('change', onChange);
   }, []);
 
-  return dimensions;
+  return (
+    <DimensionsContext.Provider value={dimensions}>
+      { children }
+    </DimensionsContext.Provider>
+  )
 };
+
+const useDimensions = () => useContext(DimensionsContext)
 
 export default useDimensions;

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -48,19 +48,21 @@ const useRestyle = <
 
   const dimensions = useDimensions();
 
-  const composedRestyleFunction = useMemo(
-    () => composeRestyleFunctions(restyleFunctions),
-    [restyleFunctions],
-  );
+  const restyled = useMemo(() => {
+    const composedRestyleFunction = composeRestyleFunctions(restyleFunctions);
+    const style = composedRestyleFunction.buildStyle(props, {
+      theme,
+      dimensions,
+    });
+    const cleanProps = filterRestyleProps(
+      props,
+      composedRestyleFunction.properties,
+    );
+    (cleanProps as TProps).style = [style, props.style].filter(Boolean);
+    return cleanProps;
+  }, [restyleFunctions, props, dimensions]);
 
-  const style = composedRestyleFunction.buildStyle(props, {theme, dimensions});
-  const cleanProps = filterRestyleProps(
-    props,
-    composedRestyleFunction.properties,
-  );
-
-  (cleanProps as TProps).style = [style, props.style].filter(Boolean);
-  return cleanProps;
+  return restyled;
 };
 
 export default useRestyle;


### PR DESCRIPTION
### PR Goal 

First of all, Thanks to all involved in creating this awesome library! The goal of this PR is to improve the overall performance.

### Issues with current implementation

Currently, every single restyled components spawn a new Dimensions Change Listener. This is very expensive especially on react-native-web because window.resize event is fired many times when the browser gets resized. On mobile, the event is basically triggered once for each orientation change, but still there are too many unnecessary listeners.

### Implementation

I have create a `DimensionsProvider` that will pass the dimensions to all components via React Context. This provider is rendered automatically as a child of `<ThemeProvider>`. So the current API is not changed, no breaking changes.

The `useDimensions` hook will read the data from context, instead of spawning its own listener. This way, there is basically 1 listener per each use of ThemeProvider.

In addition, `useRestyle` hook is also better optimised for re-renders. Previously, only the `composedRestyleFunction` was memoized, but the rest of operations for getting the final result were still executed each time the hook was called. Now, the entire result gets memoized and recalculated only if essential deps changes.

### Tests

All existing tests passed without changes. Exception here is `useRestyle.test` which is not complete, maybe it is still in development?
