### PR TITLE
Fix incorrect props when empty breakpoints

### DIFF
--- a/src/responsiveHelpers.ts
+++ b/src/responsiveHelpers.ts
@@ -1,4 +1,5 @@
 import {
+  AtLeastOneResponsiveValue,
   BaseTheme,
   Breakpoint,
   Dimensions,
@@ -31,7 +32,7 @@ export const getValueForScreenSize = <Theme extends BaseTheme, TVal>({
   breakpoints,
   dimensions,
 }: {
-  responsiveValue: {[key in keyof Theme['breakpoints']]?: TVal};
+  responsiveValue: AtLeastOneResponsiveValue<TVal, Theme>;
   breakpoints: Theme['breakpoints'];
   dimensions: Dimensions;
 }): TVal | undefined => {
@@ -63,7 +64,7 @@ export const getValueForScreenSize = <Theme extends BaseTheme, TVal>({
 export const isResponsiveObjectValue = <Theme extends BaseTheme, TVal>(
   val: ResponsiveValue<TVal, Theme>,
   theme: Theme,
-): val is {[Key in keyof Theme['breakpoints']]?: TVal} => {
+): val is AtLeastOneResponsiveValue<TVal, Theme> => {
   if (!val) return false;
   if (typeof val !== 'object') return false;
   return getKeys(val).reduce((acc: boolean, key) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,20 @@
 import {ImageStyle, TextStyle, ViewStyle} from 'react-native';
 
+export type AtLeastOneResponsiveValue<
+  Value,
+  Theme extends BaseTheme,
+  B = Theme['breakpoints'],
+  R = {[Key in keyof B]: Record<Key, Value>}
+> = Partial<
+  {
+    [K in keyof B]: Value;
+  }
+> &
+  R[keyof R];
+
 export type ResponsiveValue<Value, Theme extends BaseTheme> =
   | Value
-  | {[Key in keyof Theme['breakpoints']]?: Value};
+  | AtLeastOneResponsiveValue<Value, Theme>;
 
 export type SafeVariants<T> = Omit<T, keyof KnownBaseTheme>;
 


### PR DESCRIPTION
Fixing https://github.com/Shopify/restyle/issues/44

This PR fixes the issue of having a restyle prop with empty string or object including the case where we have no breakpoints in the theme.

❌
```jsx
<ThemeProvider theme={theme}>
    <Component backgroundColor="" />
</ThemeProvider>,
```

❌
```jsx
<ThemeProvider theme={theme}>
    <Component backgroundColor={{}} />
</ThemeProvider>,
```

✅
```jsx
<ThemeProvider theme={theme}>
    <Component backgroundColor={{phone: 'coral'}} />
</ThemeProvider>,
```

✅
```jsx
<ThemeProvider theme={theme}>
    <Component backgroundColor="coral" />
</ThemeProvider>,
```