### PR TITLE
Allow using 'auto' as value of spacing props

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface KnownBaseTheme {
     [key: string]: string;
   };
   spacing: {
-    [key: string]: number;
+    [key: string]: number | 'auto';
   };
   breakpoints: {
     [key: string]: Breakpoint;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface KnownBaseTheme {
     [key: string]: string;
   };
   spacing: {
-    [key: string]: number | 'auto';
+    [key: string]: number | string;
   };
   breakpoints: {
     [key: string]: Breakpoint;


### PR DESCRIPTION
## Summary

When defining spacing props of the theme, only numeric values are allowed. However, in some cases it also useful to use `auto` as a spacing value, [specially for margins](https://css-tricks.com/the-peculiar-magic-of-flexbox-and-auto-margins/).

This PR changes the typings of spacing props to allow usage of the string `auto` as a value as well.

