### PR TITLE
fix: Variant build stylesheet for RNW

### DIFF
--- a/src/createVariant.ts
+++ b/src/createVariant.ts
@@ -1,3 +1,5 @@
+import {StyleSheet} from 'react-native';
+
 import {
   BaseTheme,
   ResponsiveValue,
@@ -57,12 +59,14 @@ function createVariant<
       : {};
 
     if (!expandedProps && !defaults && !variantDefaults) return {};
-    return allRestyleFunctions.buildStyle(
-      {...defaults, ...variantDefaults, ...expandedProps},
-      {
-        theme,
-        dimensions,
-      },
+    return StyleSheet.flatten(
+      allRestyleFunctions.buildStyle(
+        {...defaults, ...variantDefaults, ...expandedProps},
+        {
+          theme,
+          dimensions,
+        },
+      ),
     );
   };
   return {


### PR DESCRIPTION
This PR tries to fix a bug on RNW, which consists in incorrect styles generation for variants. The issue is also mentioned [here](https://github.com/Shopify/restyle/issues/20#issuecomment-963461654) by @chris24elias 

It happened after [#94](https://github.com/Shopify/restyle/pull/94) fix, which introduced use of StyleSheet.create in buildStyle, however for createVariant this is causing incorrect styles resolution.

It can be seen in this [codesanbox](https://codesandbox.io/s/react-native-web-forked-imiqs?file=/src/App.js)

Checked this fix on the web, and variants are working as expected, with atomic classes being generated. And on RN everything works as expected. 

I understand that this library doesn't have official support for RNW, but would be nice to have variants working on the web.
