### PR TITLE
chore: less invasive theme type

### DIFF
--- a/src/createTheme.ts
+++ b/src/createTheme.ts
@@ -1,6 +1,7 @@
-import {BaseTheme} from './types';
+import {KnownBaseTheme} from './types';
 
 // Enforces proper shape for theme without throwing away the user specific values
-const createTheme = <T extends BaseTheme>(themeObject: T): T => themeObject;
+const createTheme = <T extends KnownBaseTheme>(themeObject: T): T =>
+  themeObject;
 
 export default createTheme;


### PR DESCRIPTION
With this change, and eventually providing default generics, where appropriate, you could extend restyle with the theme.
```ts
declare module '@shopify/restyle' {
  export interface BaseTheme extends AppTheme {}
}
```