### PR TITLE
Improve useRestyle performance

### DIFF
--- a/src/createRestyleComponent.tsx
+++ b/src/createRestyleComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 
+import composeRestyleFunctions from './composeRestyleFunctions';
 import {BaseTheme, RestyleFunctionContainer} from './types';
 import useRestyle from './hooks/useRestyle';
 
@@ -13,8 +14,10 @@ const createRestyleComponent = <
     | RestyleFunctionContainer<Props, Theme>[])[],
   BaseComponent: React.ComponentType<any> = View,
 ) => {
+  const composedRestyleFunction = composeRestyleFunctions(restyleFunctions);
+
   const RestyleComponent = React.forwardRef((props: Props, ref) => {
-    const passedProps = useRestyle(restyleFunctions, props);
+    const passedProps = useRestyle(composedRestyleFunction, props);
     return <BaseComponent ref={ref} {...passedProps} />;
   });
   type RestyleComponentType = typeof RestyleComponent;

--- a/src/test/useRestyle.test.tsx
+++ b/src/test/useRestyle.test.tsx
@@ -4,6 +4,7 @@ import {Text, TouchableOpacity} from 'react-native';
 import useRestyle from '../hooks/useRestyle';
 import {position, PositionProps} from '../restyleFunctions';
 import createVariant, {VariantProps} from '../createVariant';
+import composeRestyleFunctions from '../composeRestyleFunctions';
 
 const theme = {
   colors: {},
@@ -15,21 +16,27 @@ const theme = {
     phone: 0,
     tablet: 376,
   },
+  zIndices: {
+    phone: 5,
+  },
 };
 type Theme = typeof theme;
 
 type Props = VariantProps<Theme, 'buttonVariants'> &
-  PositionProps<Theme> & {
-    title: string;
-  } & ComponentPropsWithoutRef<typeof TouchableOpacity>;
+  PositionProps<Theme> &
+  ComponentPropsWithoutRef<typeof TouchableOpacity>;
 
 const restyleFunctions = [
   position,
-  createVariant({themeKey: 'buttonVariants'}),
+  createVariant<Theme>({themeKey: 'buttonVariants'}),
 ];
 
-function Button({title, ...rest}: Props) {
-  const props = useRestyle(restyleFunctions, rest);
+const composedRestyleFunction = composeRestyleFunctions<Theme, Props>(
+  restyleFunctions,
+);
+
+function Button({title, ...rest}: Props & {title: string}) {
+  const props = useRestyle(composedRestyleFunction, rest);
   return (
     <TouchableOpacity {...props}>
       <Text>{title}</Text>


### PR DESCRIPTION
## Summary

1. Instead of running composeRestyleFunctions on every render cycle, we can do it only once when creating the restyle component.

2. Build the stylesheet based only on restyle props and not all the props received by the restyled component

3. Build map used to filter between restyle props and ordinary props only once, and not on every render cycle

4. Do not apply all restyle transformations to obtain the stylesheet, only apply the transformations that are needed based on the props that are present on the restyled component

I'll add further comments on the PR diff trying to explain these changes in more detail

## Benchmark results

(Find the actual benchmark explanation below)

### Noop rerender

Rerenders without changing the component tree turned out to be ~36% faster after these changes

### Mount/Unmount 100 list items

Mounting and unmounting a list of 100 items turned out to be ~24% faster after these changes



## Benchmark

To somehow measure how/if these changes improved performance or not, I built a benchmark app: https://github.com/sbalay/restyle-benchmark

In that app, we render a list of 100 items. Each item is a bunch of `Box` and `Text` components from restyle `createBox` and `createText`.

### Test 1 (unmount/mount)

Unmount and remount the entire list and output the render cost of each operation using [React's profiler API](https://reactjs.org/docs/profiler.html). At the end of the video I output the average cost of each update.

#### Before

20 operations, average cost 102ms

https://user-images.githubusercontent.com/1928544/155322197-60e20d5d-9924-4b36-a425-ffcdd443aba1.mp4



#### After

20 operations, average cost 77ms

https://user-images.githubusercontent.com/1928544/155322192-b1bdbad4-e53a-41e1-8bf5-c24eacb46247.mp4 


### Test 2 (noop rerender)

Trigger a noop rerender of the whole list (by changing state in the parent component). Same as before, measure using React Profiler and output averages at the end


#### Before

40 operations, average cost 44ms

https://user-images.githubusercontent.com/1928544/155322334-be2a3175-7fe6-49c5-808a-3c83292a9b7f.mp4

#### After

40 operations, average cost 28ms

https://user-images.githubusercontent.com/1928544/155322351-6629ea5a-8cbe-428b-b60a-1b3bf6f5fbe8.mp4


