### PR TITLE
Handle Pressable function style prop

### DIFF
--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {StyleProp, ViewStyle, TextStyle, ImageStyle} from 'react-native';
+import {StyleProp} from 'react-native';
 
 import {BaseTheme, RNStyle, Dimensions} from '../types';
 import {getKeys} from '../typeHelpers';
@@ -53,7 +53,7 @@ const useRestyle = <
         theme: Theme;
         dimensions: Dimensions;
       },
-    ) => ViewStyle | TextStyle | ImageStyle;
+    ) => RNStyle;
     properties: (keyof TProps)[];
     propertiesMap: Record<keyof TProps, boolean>;
   },
@@ -73,11 +73,12 @@ const useRestyle = <
       dimensions,
     });
 
-    if (typeof props.style === "function") {
-      return (...args) => ({...style, ...props.style(...args)});
+    const styleProp = props.style;
+    if (typeof styleProp === 'function') {
+      return (...args: any[]) => [style, styleProp(args)];
     }
 
-    return [style, props.style].filter(Boolean);
+    return [style, styleProp].filter(Boolean);
     // We disable the exhaustive deps rule here in order to trigger the useMemo
     // when the serialized string of restyleProps changes instead of the object
     // reference which will change on every render.

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -75,10 +75,10 @@ const useRestyle = <
 
     const styleProp = props.style;
     if (typeof styleProp === 'function') {
-      return (...args: any[]) => [style, styleProp(...args)];
+      return (...args: any[]) => [style, styleProp(...args)].filter(Boolean);
     }
-
     return [style, styleProp].filter(Boolean);
+
     // We disable the exhaustive deps rule here in order to trigger the useMemo
     // when the serialized string of restyleProps changes instead of the object
     // reference which will change on every render.

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -75,7 +75,7 @@ const useRestyle = <
 
     const styleProp = props.style;
     if (typeof styleProp === 'function') {
-      return (...args: any[]) => [style, styleProp(args)];
+      return (...args: any[]) => [style, styleProp(...args)];
     }
 
     return [style, styleProp].filter(Boolean);

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -73,6 +73,12 @@ const useRestyle = <
       dimensions,
     });
 
+    if (typeof props.style === "function") {
+      return (...args) => {
+        return {...style, ...props.style(...args)};
+      }
+    }
+
     return [style, props.style].filter(Boolean);
     // We disable the exhaustive deps rule here in order to trigger the useMemo
     // when the serialized string of restyleProps changes instead of the object

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -74,9 +74,7 @@ const useRestyle = <
     });
 
     if (typeof props.style === "function") {
-      return (...args) => {
-        return {...style, ...props.style(...args)};
-      }
+      return (...args) => ({...style, ...props.style(...args)});
     }
 
     return [style, props.style].filter(Boolean);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {ImageStyle, TextStyle, ViewStyle} from 'react-native';
+import {ImageStyle, TextStyle, ViewStyle, StyleProp} from 'react-native';
 
 export type AtLeastOneResponsiveValue<
   Value,
@@ -70,7 +70,11 @@ export type RestyleFunction<
   [key in S]?: any;
 };
 
-export type RNStyle = ViewStyle | TextStyle | ImageStyle;
+export type RNStyle =
+  | ViewStyle
+  | TextStyle
+  | ImageStyle
+  | ((...args: any[]) => StyleProp<ViewStyle>);
 
 export type RNStyleProperty =
   | keyof ViewStyle


### PR DESCRIPTION
Currently when using the style prop along with Restyle provided props, only style objects are accepted but the [Pressable](https://reactnative.dev/docs/pressable#style) component also accepts a function in order to access the `pressed` state.

This PR detects if the style prop is a function and if so, returns another function that merges the Restyle generated styles and the style prop styles.

I just threw together this fix in a few minutes so maybe there is some edge cases I haven't thought of, feel free to disregard if the problem is actually a lot harder then my small fix. It does work locally for me at least.

Thanks!

Should resolve https://github.com/Shopify/restyle/issues/58