### PR TITLE
Fix default variant not being applied

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ const {defaults: tsjPreset} = require('ts-jest/presets');
 
 module.exports = {
   ...tsjPreset,
+  testEnvironment: 'jsdom',
   preset: 'react-native',
   transform: {
     ...tsjPreset.transform,

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,6 @@ const {defaults: tsjPreset} = require('ts-jest/presets');
 
 module.exports = {
   ...tsjPreset,
-  testEnvironment: 'jsdom',
   preset: 'react-native',
   transform: {
     ...tsjPreset.transform,

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -11,9 +11,12 @@ const filterRestyleProps = <
   TRestyleProps,
   TProps extends Record<string, unknown> & TRestyleProps
 >(
-  props: TProps,
+  componentProps: TProps,
   omitPropertiesMap: Record<keyof TProps, boolean>,
 ) => {
+  const props = omitPropertiesMap.variant
+    ? {variant: 'defaults', ...componentProps}
+    : componentProps;
   return getKeys(props).reduce(
     ({cleanProps, restyleProps, serializedRestyleProps}, key) => {
       if (omitPropertiesMap[key as keyof TProps]) {
@@ -63,7 +66,7 @@ const useRestyle = <
   const dimensions = useDimensions();
 
   const {cleanProps, restyleProps, serializedRestyleProps} = filterRestyleProps(
-    {variant: 'defaults', ...props},
+    props,
     composedRestyleFunction.propertiesMap,
   );
 

--- a/src/hooks/useRestyle.ts
+++ b/src/hooks/useRestyle.ts
@@ -63,7 +63,7 @@ const useRestyle = <
   const dimensions = useDimensions();
 
   const {cleanProps, restyleProps, serializedRestyleProps} = filterRestyleProps(
-    props,
+    {variant: 'defaults', ...props},
     composedRestyleFunction.propertiesMap,
   );
 

--- a/src/test/createRestyleComponent.test.tsx
+++ b/src/test/createRestyleComponent.test.tsx
@@ -48,14 +48,20 @@ const themeWithVariant = {
 type Theme = typeof theme;
 type ThemeWithVariant = typeof themeWithVariant;
 
-jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
-  return {
-    get: () => ({
-      width: 375,
-      height: 667,
-    }),
-    addEventListener: jest.fn(),
-  };
+jest.mock('react-native', () => {
+  return Object.setPrototypeOf(
+    {
+      Dimensions: {
+        get: () => ({
+          width: 375,
+          height: 667,
+        }),
+        addEventListener: jest.fn(() => ({remove: () => {}})),
+        removeEventListener: jest.fn(),
+      },
+    },
+    jest.requireActual('react-native'),
+  );
 });
 
 const Component = createRestyleComponent<
@@ -163,7 +169,7 @@ describe('createRestyleComponent', () => {
       );
     });
 
-    it('passes styles form default variant when no variant prop is defined', () => {
+    it('passes styles from default variant when no variant prop is defined', () => {
       const {root} = render(
         <ThemeProvider theme={themeWithVariant}>
           <ComponentWithVariant margin="s" />
@@ -178,7 +184,7 @@ describe('createRestyleComponent', () => {
       ]);
     });
 
-    it('passes styles form the defined variant', () => {
+    it('passes styles from the defined variant', () => {
       const {root} = render(
         <ThemeProvider theme={themeWithVariant}>
           <ComponentWithVariant variant="regular" margin="s" />

--- a/src/test/createRestyleComponent.test.tsx
+++ b/src/test/createRestyleComponent.test.tsx
@@ -12,10 +12,13 @@ import {
   opacity,
 } from '../restyleFunctions';
 import {ThemeProvider} from '../context';
+import createVariant, {VariantProps} from '../createVariant';
 
 const theme = {
   colors: {
     coral: '#FFE6E4',
+    lightcyan: '#E0FFFF',
+    lightpink: '#FFB6C1',
   },
   spacing: {},
   breakpoints: {
@@ -25,6 +28,16 @@ const theme = {
   opacities: {
     barelyVisible: 0.1,
     almostOpaque: 0.9,
+  },
+  cardVariants: {
+    defaults: {
+      alignItems: 'flex-start',
+      backgroundColor: 'lightpink',
+    },
+    regular: {
+      alignItems: 'center',
+      backgroundColor: 'lightcyan',
+    },
   },
 };
 type Theme = typeof theme;
@@ -38,13 +51,18 @@ jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
     addEventListener: jest.fn(),
   };
 });
+
+const cardVariant = createVariant<Theme, 'cardVariants'>({
+  themeKey: 'cardVariants',
+});
 const Component = createRestyleComponent<
   BackgroundColorProps<Theme> &
     SpacingProps<Theme> &
     OpacityProps<Theme> &
+    VariantProps<Theme, 'cardVariants'> &
     ViewProps,
   Theme
->([backgroundColor, spacing, opacity]);
+>([backgroundColor, spacing, opacity, cardVariant]);
 
 describe('createRestyleComponent', () => {
   describe('creates a component that', () => {
@@ -53,22 +71,36 @@ describe('createRestyleComponent', () => {
     });
 
     it('passes styles based on the given props', () => {
-      const {root} = render(<Component opacity={0.5} />);
-      expect(root.findByType(View).props.style).toStrictEqual([{opacity: 0.5}]);
+      const {root} = render(
+        <ThemeProvider theme={theme}>
+          <Component opacity={0.5} />{' '}
+        </ThemeProvider>,
+      );
+      expect(root.findByType(View).props.style).toStrictEqual([
+        expect.objectContaining({opacity: 0.5}),
+      ]);
     });
 
     it('appends style prop to the end', () => {
-      const {root} = render(<Component opacity={0.5} style={{width: 100}} />);
+      const {root} = render(
+        <ThemeProvider theme={theme}>
+          <Component opacity={0.5} style={{width: 100}} />
+        </ThemeProvider>,
+      );
       expect(root.findByType(View).props.style).toStrictEqual([
-        {opacity: 0.5},
+        expect.objectContaining({opacity: 0.5}),
         {width: 100},
       ]);
     });
 
     it('does not pass styling properties to the child', () => {
-      const {root} = render(<Component opacity={0.5} pointerEvents="auto" />);
+      const {root} = render(
+        <ThemeProvider theme={theme}>
+          <Component opacity={0.5} pointerEvents="auto" />
+        </ThemeProvider>,
+      );
       expect(root.findByType(View).props).toStrictEqual({
-        style: [{opacity: 0.5}],
+        style: [expect.objectContaining({opacity: 0.5})],
         pointerEvents: 'auto',
       });
     });
@@ -80,7 +112,7 @@ describe('createRestyleComponent', () => {
         </ThemeProvider>,
       );
       expect(root.findByType(View).props).toStrictEqual({
-        style: [{backgroundColor: '#FFE6E4'}],
+        style: [expect.objectContaining({backgroundColor: '#FFE6E4'})],
       });
     });
 
@@ -92,7 +124,7 @@ describe('createRestyleComponent', () => {
         </ThemeProvider>,
       );
       expect(root.findByType(View).props).toStrictEqual({
-        style: [{opacity: 0.5}],
+        style: [expect.objectContaining({opacity: 0.5})],
       });
       await new Promise(resolve => setTimeout(resolve, 0));
       const {calls} = (Dimensions.addEventListener as jest.Mock).mock;
@@ -101,13 +133,17 @@ describe('createRestyleComponent', () => {
         onChange({window: {width: 768, height: 1024}});
       });
       expect(root.findByType(View).props).toStrictEqual({
-        style: [{opacity: 0.8}],
+        style: [expect.objectContaining({opacity: 0.8})],
       });
     });
 
     it('forwards refs', () => {
       const spy = jest.fn();
-      render(<Component ref={spy} testID="RENDERED_COMPONENT" />);
+      render(
+        <ThemeProvider theme={theme}>
+          <Component ref={spy} testID="RENDERED_COMPONENT" />
+        </ThemeProvider>,
+      );
 
       expect(spy).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/test/createRestyleComponent.test.tsx
+++ b/src/test/createRestyleComponent.test.tsx
@@ -20,7 +20,9 @@ const theme = {
     lightcyan: '#E0FFFF',
     lightpink: '#FFB6C1',
   },
-  spacing: {},
+  spacing: {
+    s: 8,
+  },
   breakpoints: {
     phone: 0,
     tablet: 376,
@@ -29,6 +31,9 @@ const theme = {
     barelyVisible: 0.1,
     almostOpaque: 0.9,
   },
+};
+const themeWithVariant = {
+  ...theme,
   cardVariants: {
     defaults: {
       alignItems: 'flex-start',
@@ -41,6 +46,7 @@ const theme = {
   },
 };
 type Theme = typeof theme;
+type ThemeWithVariant = typeof themeWithVariant;
 
 jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
   return {
@@ -52,16 +58,23 @@ jest.mock('react-native/Libraries/Utilities/Dimensions', () => {
   };
 });
 
-const cardVariant = createVariant<Theme, 'cardVariants'>({
-  themeKey: 'cardVariants',
-});
 const Component = createRestyleComponent<
   BackgroundColorProps<Theme> &
     SpacingProps<Theme> &
     OpacityProps<Theme> &
-    VariantProps<Theme, 'cardVariants'> &
     ViewProps,
   Theme
+>([backgroundColor, spacing, opacity]);
+const cardVariant = createVariant<ThemeWithVariant, 'cardVariants'>({
+  themeKey: 'cardVariants',
+});
+const ComponentWithVariant = createRestyleComponent<
+  BackgroundColorProps<ThemeWithVariant> &
+    SpacingProps<ThemeWithVariant> &
+    OpacityProps<ThemeWithVariant> &
+    VariantProps<ThemeWithVariant, 'cardVariants'> &
+    ViewProps,
+  ThemeWithVariant
 >([backgroundColor, spacing, opacity, cardVariant]);
 
 describe('createRestyleComponent', () => {
@@ -76,9 +89,7 @@ describe('createRestyleComponent', () => {
           <Component opacity={0.5} />
         </ThemeProvider>,
       );
-      expect(root.findByType(View).props.style).toStrictEqual([
-        expect.objectContaining({opacity: 0.5}),
-      ]);
+      expect(root.findByType(View).props.style).toStrictEqual([{opacity: 0.5}]);
     });
 
     it('appends style prop to the end', () => {
@@ -88,7 +99,7 @@ describe('createRestyleComponent', () => {
         </ThemeProvider>,
       );
       expect(root.findByType(View).props.style).toStrictEqual([
-        expect.objectContaining({opacity: 0.5}),
+        {opacity: 0.5},
         {width: 100},
       ]);
     });
@@ -100,7 +111,7 @@ describe('createRestyleComponent', () => {
         </ThemeProvider>,
       );
       expect(root.findByType(View).props).toStrictEqual({
-        style: [expect.objectContaining({opacity: 0.5})],
+        style: [{opacity: 0.5}],
         pointerEvents: 'auto',
       });
     });
@@ -112,7 +123,7 @@ describe('createRestyleComponent', () => {
         </ThemeProvider>,
       );
       expect(root.findByType(View).props).toStrictEqual({
-        style: [expect.objectContaining({backgroundColor: '#FFE6E4'})],
+        style: [{backgroundColor: '#FFE6E4'}],
       });
     });
 
@@ -124,7 +135,7 @@ describe('createRestyleComponent', () => {
         </ThemeProvider>,
       );
       expect(root.findByType(View).props).toStrictEqual({
-        style: [expect.objectContaining({opacity: 0.5})],
+        style: [{opacity: 0.5}],
       });
       await new Promise(resolve => setTimeout(resolve, 0));
       const {calls} = (Dimensions.addEventListener as jest.Mock).mock;
@@ -133,7 +144,7 @@ describe('createRestyleComponent', () => {
         onChange({window: {width: 768, height: 1024}});
       });
       expect(root.findByType(View).props).toStrictEqual({
-        style: [expect.objectContaining({opacity: 0.8})],
+        style: [{opacity: 0.8}],
       });
     });
 
@@ -154,29 +165,31 @@ describe('createRestyleComponent', () => {
 
     it('passes styles form default variant when no variant prop is defined', () => {
       const {root} = render(
-        <ThemeProvider theme={theme}>
-          <Component />
+        <ThemeProvider theme={themeWithVariant}>
+          <ComponentWithVariant margin="s" />
         </ThemeProvider>,
       );
       expect(root.findByType(View).props.style).toStrictEqual([
-        expect.objectContaining({
+        {
           alignItems: 'flex-start',
           backgroundColor: '#FFB6C1',
-        }),
+          margin: 8,
+        },
       ]);
     });
 
     it('passes styles form the defined variant', () => {
       const {root} = render(
-        <ThemeProvider theme={theme}>
-          <Component variant="regular" />
+        <ThemeProvider theme={themeWithVariant}>
+          <ComponentWithVariant variant="regular" margin="s" />
         </ThemeProvider>,
       );
       expect(root.findByType(View).props.style).toStrictEqual([
-        expect.objectContaining({
+        {
           alignItems: 'center',
           backgroundColor: '#E0FFFF',
-        }),
+          margin: 8,
+        },
       ]);
     });
   });

--- a/src/test/createRestyleComponent.test.tsx
+++ b/src/test/createRestyleComponent.test.tsx
@@ -73,7 +73,7 @@ describe('createRestyleComponent', () => {
     it('passes styles based on the given props', () => {
       const {root} = render(
         <ThemeProvider theme={theme}>
-          <Component opacity={0.5} />{' '}
+          <Component opacity={0.5} />
         </ThemeProvider>,
       );
       expect(root.findByType(View).props.style).toStrictEqual([
@@ -150,6 +150,34 @@ describe('createRestyleComponent', () => {
           props: expect.objectContaining({testID: 'RENDERED_COMPONENT'}),
         }),
       );
+    });
+
+    it('passes styles form default variant when no variant prop is defined', () => {
+      const {root} = render(
+        <ThemeProvider theme={theme}>
+          <Component />
+        </ThemeProvider>,
+      );
+      expect(root.findByType(View).props.style).toStrictEqual([
+        expect.objectContaining({
+          alignItems: 'flex-start',
+          backgroundColor: '#FFB6C1',
+        }),
+      ]);
+    });
+
+    it('passes styles form the defined variant', () => {
+      const {root} = render(
+        <ThemeProvider theme={theme}>
+          <Component variant="regular" />
+        </ThemeProvider>,
+      );
+      expect(root.findByType(View).props.style).toStrictEqual([
+        expect.objectContaining({
+          alignItems: 'center',
+          backgroundColor: '#E0FFFF',
+        }),
+      ]);
     });
   });
 });


### PR DESCRIPTION
## What:

Fix default variant not being applied.

More info can be found in here [issue](https://github.com/Shopify/restyle/issues/145)

PS: this bug is not related only to components created using `createText` but instead to all components using `createRestyleComponent`