### PR TITLE
Add includeFontPadding typography property.

### DIFF
--- a/src/restyleFunctions.ts
+++ b/src/restyleFunctions.ts
@@ -57,6 +57,7 @@ const typographyProperties = {
   textDecorationLine: true,
   textDecorationStyle: true,
   textTransform: true,
+  includeFontPadding: true,
 };
 
 const layoutProperties = {


### PR DESCRIPTION
This PR adds the standard includeFontPadding property which is used for the Text component on Android.

I am using `restyle` with `react-native-typography` which makes use of `includeFontPadding`. The missing property was causing a hard crash because the restyle function was missing from the function map.

I have tested and found that this fixes my problem.