### PR TITLE
Add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,39 @@
+---
+name: "\U0001F41B Bug report"
+about: Report an issue with @shopify/restyle to help us improve
+labels: 'bug'
+---
+
+<!-- Thanks for taking the time to fill out this bug report!
+
+If this is not a bug report, please use other relevant channels:
+- [Create a feature proposal on Discussions](https://github.com/Shopify/restyle/discussions/new)
+- [Chat with others in the #restyle channel on Shopify React Native Open Source Discord](https://discord.gg/k2gzABTfav)
+
+Before you proceed:
+
+- Make sure you are on latest versions of the @shopify/restyle package.
+- If you are having an issue with your machine or build tools, the issue belongs on another repository as that is outside of the scope of Restyle. -->
+
+## Current behavior
+
+<!-- What code are you running and what is happening? Include a screenshot or video if it's a UI related issue. -->
+
+## Expected behavior
+
+<!-- What do you expect to happen instead? -->
+
+## To Reproduce
+
+<!-- Please provide a way to reproduce the problem if it's possible. Use the fixture app to create an example that reproduces the bug and provide a link to a GitHub repository under your username. -->
+
+## Platform:
+
+- [ ] iOS
+- [ ] Android
+
+## Environment
+
+<!-- What is the exact version of @shopify/restyle that you are using? -->
+
+x.y.z

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/Shopify/restyle
+    about: Read the official documentation.
+  - name: Discussions
+    url: https://github.com/Shopify/restyle/discussions
+    about: Discuss questions, ideas etc. and share resources related to the library.
+  - name: Shopify React Native Open Source Discord
+    url: https://discord.gg/k2gzABTfav
+    about: Chat with other community members in the restyle channel on Shopify React Native Open Source Discord.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+
+Fixes (issue #)
+
+<!--
+Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
+-->
+
+## Reviewers’ hat-rack :tophat:
+
+<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->
+
+- [ ]
+
+## Screenshots or videos (if needed)
+
+<!-- Showcase the working feature to make testing easier. -->
+
+## Checklist
+
+- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.


### PR DESCRIPTION
This PR adds GitHub templates for PRs and issues, similarly as we do for [flash-list](https://github.com/Shopify/flash-list).

With this, any feature requests or questions should also be flagged in [discussions](https://github.com/Shopify/restyle/discussions) and not in issues which should be primarily for bugs.