### PR TITLE
Improve fixture package scripts and add CI

### DIFF
--- a/.github/workflows/restyle.yml
+++ b/.github/workflows/restyle.yml
@@ -32,6 +32,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - run: |
           yarn
+          yarn build
           cd fixture
           yarn
           yarn build:android

--- a/.github/workflows/restyle.yml
+++ b/.github/workflows/restyle.yml
@@ -59,6 +59,8 @@ jobs:
       - run: |
           yarn
           yarn test --forceExit
+  # Note that we decided not to build the iOS fixture app as it would take around 30 minutes. Since updates to the fixture app
+  # will generally not contain native code changes, the build is not entirely necessary and can be added in the future if needed.
   build-android:
     name: 'Build Android'
     runs-on: ubuntu-latest

--- a/.github/workflows/restyle.yml
+++ b/.github/workflows/restyle.yml
@@ -72,7 +72,6 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - run: |
-          bundle install
           cd fixture
           yarn
           cd android

--- a/.github/workflows/restyle.yml
+++ b/.github/workflows/restyle.yml
@@ -21,6 +21,20 @@ jobs:
       - run: |
           yarn
           yarn build
+  build-fixture-ts:
+    name: 'Build fixture Typescript'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: |
+          yarn
+          cd fixture
+          yarn
+          yarn build:android
+          yarn build:ios
   lint-ts:
     name: 'Lint Typescript'
     runs-on: ubuntu-latest
@@ -43,3 +57,22 @@ jobs:
       - run: |
           yarn
           yarn test --forceExit
+  build-android:
+    name: 'Build Android'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: ruby setup
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - run: |
+          bundle install
+          cd fixture
+          yarn
+          cd android
+          ./gradlew assembleDebug

--- a/.github/workflows/restyle.yml
+++ b/.github/workflows/restyle.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
 
 env:
+  RUBY_VERSION: 3.0.3
   NODE_VERSION: 19.1.0
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "test": "jest",
     "lint": "eslint '**/*.{ts,tsx}' && yarn tsc --noEmit",
     "lint-fix": "eslint --fix '**/*.{ts,tsx}'",
-    "prepublishOnly": "yarn run build"
+    "prepublishOnly": "yarn run build",
+    "up": "yarn && yarn fixture-up",
+    "fixture-up": "cd fixture && yarn && pod install --project-directory=ios",
+    "start": "cd fixture && react-native start",
+    "run-ios": "cd fixture && yarn react-native run-ios",
+    "run-android": "cd fixture && yarn react-native run-android"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Description
Improves the fixture app's package scripts and adds CI.

The package scripts added are:
- up: Prepares restyle and also the fixture app through `fixture up`
- fixture up: Prepares the fixture app by running yarn and installing pods for iOS
- start: Runs metro
- run-ios: Runs the iOS fixture app
- run-android: Runs the Android fixture app

For CI, this PR adds pipelines to build the fixture's TypeScript code and build the Android app. We decided to not build the iOS app as it would take ~30mins (see time in flashlist for reference). Since updates to the app will generally not contain native code, this check is not entirely necessary and we will add it in the future if it does become needed.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->
1. CI ✅ 
2. Run the package scripts above in the root folder using `yarn <command>` and confirm that they all work properly


## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
