### PR TITLE
Fix node version in gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   RUBY_VERSION: 3.0.3
-  NODE_VERSION: 19.14.0
+  NODE_VERSION: 16.13.0
 
 jobs:
   release:


### PR DESCRIPTION
## Description
Currently using an unsupported version of node in the gh-pages workflow ([see here](https://github.com/Shopify/restyle/blob/master/.github/workflows/gh-pages.yml#L9)). As seen in the `actions/setup-node` library, [v3 only supports node 16](https://github.com/actions/setup-node/releases/tag/v3.0.0). The v3 release can be [seen here](https://github.com/actions/setup-node/releases).

Fixes

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:
Once merged, does the docs site properly get built to gh pages

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
