### PR TITLE
Save theme memoization in a local WeakMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Next
 
+- Fixed: New property error when using `react-native-reanimated` `v3.0.0` by memoizing style values in a separate `WeakMap` [#237](https://github.com/Shopify/restyle/pull/237) by [fortmarek](https://github.com/fortmarek)
+
 ## 2.4.0 - 2023-02-21
 
 - Improve restyle performance [#220](https://github.com/Shopify/restyle/pull/220) by [fortmarek](https://github.com/fortmarek)

--- a/src/createRestyleFunction.ts
+++ b/src/createRestyleFunction.ts
@@ -18,9 +18,7 @@ const getMemoizedMapHashKey = (
   return `${dimensions?.height}x${dimensions?.width}-${themeKey}-${property}-${value}`;
 };
 
-type ThemeWithMemoization<Theme extends BaseTheme> = Theme & {
-  unsafeMemoizedMap: {[key: string]: any} | null;
-};
+const memoizedThemes: WeakMap<BaseTheme, any> = new WeakMap();
 
 const createRestyleFunction = <
   Theme extends BaseTheme = BaseTheme,
@@ -45,11 +43,8 @@ const createRestyleFunction = <
     props,
     {theme, dimensions},
   ) => {
-    // We reuse the theme object for saving the memoized values.
-    const unsafeTheme: ThemeWithMemoization<Theme> =
-      theme as ThemeWithMemoization<Theme>;
-    if (unsafeTheme.unsafeMemoizedMap == null) {
-      unsafeTheme.unsafeMemoizedMap = {};
+    if (memoizedThemes.get(theme) == null) {
+      memoizedThemes.set(theme, {});
     }
 
     const memoizedMapHashKey = (() => {
@@ -72,7 +67,7 @@ const createRestyleFunction = <
     })();
 
     if (memoizedMapHashKey != null) {
-      const memoizedValue = unsafeTheme.unsafeMemoizedMap[memoizedMapHashKey];
+      const memoizedValue = memoizedThemes.get(theme)[memoizedMapHashKey];
       if (memoizedValue != null) {
         return memoizedValue;
       }
@@ -93,10 +88,10 @@ const createRestyleFunction = <
     if (value === undefined) return {};
 
     if (memoizedMapHashKey != null) {
-      unsafeTheme.unsafeMemoizedMap[memoizedMapHashKey] = {
+      memoizedThemes.get(theme)[memoizedMapHashKey] = {
         [styleProp]: value,
       };
-      return unsafeTheme.unsafeMemoizedMap[memoizedMapHashKey];
+      return memoizedThemes.get(theme)[memoizedMapHashKey];
     }
     return {
       [styleProp]: value,


### PR DESCRIPTION
## Description

When upgrading to `react-native-reanimated` to `3.0.0`, the app was crashing immediately upon opening with the following error:

<img alt="Restyle crash screenshot" src="https://user-images.githubusercontent.com/9371695/222388181-3fea7df4-382b-49dc-a0f0-b7ebe6fab60a.png" width="400" />

Turns out, `react-native-reanimated` [freezes objects](https://github.com/software-mansion/react-native-reanimated/blob/18b6f2c7b681b608463c961e3e3b488c9d1c169f/src/reanimated2/shareables.ts#L95-L101) that are transformed to shareable – recursively. This means that `theme` was frozen and subsequently also the memoziation map we save to the theme was, too.

Instead of saving the memoziation directly inside the theme object, we can create a new [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) where the key is the theme itself and the value is the memoization map.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- Try out app with `react-native-reanimated` 3.0.0 -> it should not crash

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
