### PR TITLE
Fix custom themed nested components props overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Next
 
+- Fixed: Variant with breakpoints memoizing separate values into the same hash key by deconstructing breakpoint objects into strings [#241](https://github.com/Shopify/restyle/pull/241) by [mattfrances](https://github.com/mattfrances)
+
 ## 2.4.1 - 2023-03-02
 
 - Fixed: New property error when using `react-native-reanimated` `v3.0.0` by memoizing style values in a separate `WeakMap` [#237](https://github.com/Shopify/restyle/pull/237) by [fortmarek](https://github.com/fortmarek)

--- a/src/createRestyleFunction.ts
+++ b/src/createRestyleFunction.ts
@@ -55,11 +55,37 @@ const createRestyleFunction = <
         typeof themeKey === 'string' &&
         typeof property === 'string'
       ) {
+        /*
+        The following code is required to ensure all variants that have different breakpoint objects are turned into unique strings. By simply retuning String(props[property]), two different variants with breakpoints will return the same string.
+        For example, if we have the following variant:
+          spacingVariant: {
+            defaults: {},
+            noPadding: {
+              phone: 'none',
+              tablet: 'none',
+            },
+            mediumPadding: {
+              phone: 'm',
+              tablet: 'm',
+            }
+          }
+        using String(props[property]) will turn both variants into [object Object], making them equivalent and resulting in separate styles being memoized into the same hash key.
+        By building the propertyValue string ourselves from the breakpoints, we can format the variants to be "phone:nonetablet:none" and "phone:mtablet:m" respectively, making each memoized hash key unique.
+        */
+        let propertyValue = '';
+        if (typeof props[property] === 'object') {
+          for (const [breakpoint, value] of Object.entries(props[property])) {
+            propertyValue += `${breakpoint}:${value}`;
+          }
+        } else {
+          propertyValue = String(props[property]);
+        }
+
         return getMemoizedMapHashKey(
           dimensions,
           String(themeKey),
           String(property),
-          String(props[property]),
+          propertyValue,
         );
       } else {
         return null;

--- a/src/test/TestButton.tsx
+++ b/src/test/TestButton.tsx
@@ -1,0 +1,45 @@
+import React, {ComponentPropsWithoutRef} from 'react';
+import {Text, TouchableOpacity} from 'react-native';
+
+import useRestyle from '../hooks/useRestyle';
+import {position, PositionProps} from '../restyleFunctions';
+import createVariant, {VariantProps} from '../createVariant';
+import composeRestyleFunctions from '../composeRestyleFunctions';
+
+const theme = {
+  colors: {},
+  spacing: {},
+  buttonVariants: {
+    defaults: {},
+  },
+  breakpoints: {
+    phone: 0,
+    tablet: 376,
+  },
+  zIndices: {
+    phone: 5,
+  },
+};
+type Theme = typeof theme;
+
+type Props = VariantProps<Theme, 'buttonVariants'> &
+  PositionProps<Theme> &
+  ComponentPropsWithoutRef<typeof TouchableOpacity>;
+
+const restyleFunctions = [
+  position,
+  createVariant<Theme>({themeKey: 'buttonVariants'}),
+];
+
+const composedRestyleFunction = composeRestyleFunctions<Theme, Props>(
+  restyleFunctions,
+);
+
+export function Button({title, ...rest}: Props & {title: string}) {
+  const props = useRestyle(composedRestyleFunction, rest);
+  return (
+    <TouchableOpacity {...props}>
+      <Text>{title}</Text>
+    </TouchableOpacity>
+  );
+}

--- a/src/test/TestContainer.tsx
+++ b/src/test/TestContainer.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {View, ViewProps} from 'react-native';
+
+import useRestyle from '../hooks/useRestyle';
+import createVariant, {VariantProps} from '../createVariant';
+import composeRestyleFunctions from '../composeRestyleFunctions';
+import {
+  backgroundColor,
+  BackgroundColorProps,
+  BorderProps,
+  spacing,
+  SpacingProps,
+} from '../restyleFunctions';
+
+const palette = {
+  purple: '#5A31F4',
+  green: '#099C77',
+  black: '#101010',
+  white: '#FFF',
+};
+
+export const theme = {
+  colors: {
+    background: palette.purple,
+  },
+  spacing: {
+    none: 0,
+    m: 8,
+  },
+  breakpoints: {
+    phone: 320,
+    tablet: 768,
+  },
+  spacingVariant: {
+    defaults: {},
+    spacingParent: {
+      padding: {
+        phone: 'none',
+        tablet: 'none',
+      },
+    },
+    spacingNested: {
+      padding: {
+        phone: 'm',
+        tablet: 'm',
+      },
+    },
+  },
+};
+type Theme = typeof theme;
+
+type RestyleProps = SpacingProps<Theme> &
+  BorderProps<Theme> &
+  BackgroundColorProps<Theme> &
+  VariantProps<Theme, 'spacingVariant'>;
+
+const restyleFunctions = composeRestyleFunctions<Theme, RestyleProps>([
+  spacing,
+  backgroundColor,
+  createVariant({themeKey: 'spacingVariant'}),
+]);
+
+type Props = RestyleProps & ViewProps;
+
+export const Container = ({children, ...rest}: Props) => {
+  const props = useRestyle(restyleFunctions, rest);
+  return <View {...props}>{children}</View>;
+};

--- a/src/test/createRestyleFunction.test.ts
+++ b/src/test/createRestyleFunction.test.ts
@@ -4,14 +4,14 @@ import {RNStyle} from '../types';
 const theme = {
   colors: {},
   spacing: {},
-  breakpoints: {
-    phone: 0,
-    tablet: 376,
-  },
   opacities: {
     invisible: 0,
     barelyVisible: 0.1,
     almostOpaque: 0.9,
+  },
+  breakpoints: {
+    phone: 0,
+    tablet: 376,
   },
 };
 const dimensions = {


### PR DESCRIPTION
## Description

Note: This was a team effort with @ElviraBurchik!

**The issue**
When using nested components with different variant values and breakpoints, the child was receiving the parent's value.
For example with the following variant, if the child had `mediumPadding` and the parent had `noPadding`, the child ended up with a padding of 'none' / 0 rather than 'm' / 8:
```
spacingVariant: {
            defaults: {},
            noPadding: {
              phone: 'none',
              tablet: 'none',
            },
            mediumPadding: {
              phone: 'm',
              tablet: 'm',
            }
          }
```

**Why this happened**
This was happening because when memoizing properties that were objects, we were [converting them to Strings](https://github.com/Shopify/restyle/blob/master/src/createRestyleFunction.ts#L62) resulting in a memoized hash key ending with `"[object Object]"`. So the flow for nested components with variants was as follows:
1. Parent's props get memoized into a hash key -> `"1334x750-spacing-padding-[object Object]"`
2. The memoized has key [now refers to the parent's props](https://github.com/Shopify/restyle/blob/master/src/createRestyleFunction.ts#L92) (in this case padding of 0)
3. Child's props get memoized into a hash key -> `"1334x750-spacing-padding-[object Object]"`
4. Since it's the same hash key as above, we return padding of 0

**The fix**
By stringifying properties that are objects, we create unique hash keys for each case. For the example above, this would result in two separate hash keys for each variant: 
1. `"1334x750-spacing-padding-{"phone":"none","tablet":"none"}"`
2. `"1334x750-spacing-padding-{"phone":"m","tablet":"m"}"`

As a result, we wouldn't accidentally use the parent's hash key / styles.

----

The comment I added in the code is quite messy, and may be inaccurate as I'm still trying to completely understand how this works. I will update the code comment once I have some reviews and the chance to better understand how this fixes the issue.

Fixes https://github.com/Shopify/restyle/issues/239

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [ ] CI
- [ ] `yarn test useRestyle` - tests should all pass

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
