### PR TITLE
Add textVariants to docs

### DIFF
--- a/documentation/docs/fundamentals/defining-your-theme.md
+++ b/documentation/docs/fundamentals/defining-your-theme.md
@@ -34,6 +34,19 @@ const theme = createTheme({
     l: 24,
     xl: 40,
   },
+  textVariants: {
+    header: {
+      fontWeight: 'bold',
+      fontSize: 34,
+    },
+    body: {
+      fontSize: 16,
+      lineHeight: 24,
+    },
+    defaults: {
+      // We can define a default text variant here.
+    },
+  },
 });
 
 export type Theme = typeof theme;


### PR DESCRIPTION
## Description
<img width="180" align="right" alt="Screenshot 2021-12-02 at 13 31 39" src="https://user-images.githubusercontent.com/1921046/230094939-89e5ae7d-76eb-4017-9cc9-ea20fcbe3dbc.png">

When going through the docs one of the first thing you need to do is to define your theme (https://shopify.github.io/restyle/fundamentals/defining-your-theme). The example in this section however doesn't include the `textVariants` property.

This is not an immediate issue, but as soon as you start using the `<Text />` component the app will crash because it requires this property. This can cause a bit of frustration and confusion.

## Reviewers’ hat-rack :tophat:
To see the new documentation, follow these steps:

1. Check out this branch locally
2. `cd documentation && yarn && yarn start`
3. Go to http://localhost:3000/restyle/fundamentals/defining-your-theme

You'll now see the new updated documentation






## Screenshots or videos (if needed)

| Before | After |
|--------|-------|
| ![Screenshot 2023-04-05 at 15 30 53](https://user-images.githubusercontent.com/1921046/230095742-81c83777-1d97-4079-85a6-c0d09f6a2de3.png)  | ![Screenshot 2023-04-05 at 15 30 36](https://user-images.githubusercontent.com/1921046/230095753-e7d99dcd-3a45-4447-9223-9a38009fa070.png) |











## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
