### PR TITLE
Update variants.md

### DIFF
--- a/documentation/docs/fundamentals/variants.md
+++ b/documentation/docs/fundamentals/variants.md
@@ -49,7 +49,7 @@ const theme = createTheme({
 
 import {createVariant, createRestyleComponent, VariantProps} from '@shopify/restyle'
 import {Theme} from './theme';
-const variant = createVariant<Theme>({themeKey: 'cardVariants', defaults: {
+const variant = createVariant<Theme, 'cardVariant'>({themeKey: 'cardVariants', defaults: {
   margin: {
     phone: 's',
     tablet: 'm',


### PR DESCRIPTION
## Description
Based on this [issue](https://github.com/Shopify/restyle/issues/250) there is a typescript problem that throws an error on trying to create a variant. In the issue there was a fix indicating that if we specify the name of the key like:

`const variant = createVariant<Theme, 'buttonVariants'>({
  themeKey: 'buttonVariants',
  defaults: {
    margin: 'm',
  },
})
`

the ts error goes away. I updated the docs because this caused me a 1 day delay to search and fix.
