### PR TITLE
Fix dist folder not being generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 
 # IDE
 .idea
+
+tsconfig.tsbuildinfo

--- a/fixture/ios/Podfile.lock
+++ b/fixture/ios/Podfile.lock
@@ -532,7 +532,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: a31ac2336aea59512b5b982f8e231f65d7d148e1
   FBReactNativeSpec: 0976da6bc1ebd3ea9b3a65d04be2c0117d304c4c
@@ -578,4 +578,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: a12b35c724cb1bdee90e7aa425ae51bb9b251d22
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "composite": true,
     "outDir": "./dist",
     "baseUrl": "./src",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "noEmit": false
   },
   "extends": "./shared/tsconfig.base.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],


### PR DESCRIPTION
## Description

There was a config problem due to which `dist` folder was not being generated. This happened because we were extending RNs ts config which has `noEmit: true`. To fix this we've changed to `noEmit: false` in our config.

## Reviewers’ hat-rack :tophat:

<!-- Tophatting instructions, and/or what you want reviewers to concentrate on. -->

- [x] Check if fixture is working properly

## Screenshots or videos (if needed)

<!-- Showcase the working feature to make testing easier. -->

## Checklist

- [x] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
