### PR TITLE
Fix reduce function being used incorrectly in core app path

### DIFF
--- a/src/composeRestyleFunctions.ts
+++ b/src/composeRestyleFunctions.ts
@@ -28,15 +28,15 @@ const composeRestyleFunctions = <
   const properties = flattenedRestyleFunctions.map(styleFunc => {
     return styleFunc.property;
   });
-  const propertiesMap = properties.reduce(
-    (acc, prop) => ({...acc, [prop]: true}),
-    {} as {[key in keyof TProps]: true},
-  );
+  const propertiesMap = properties.reduce((acc, prop) => {
+    acc[prop] = true;
+    return acc;
+  }, {} as {[key in keyof TProps]: true});
 
-  const funcsMap = flattenedRestyleFunctions.reduce(
-    (acc, each) => ({[each.property]: each.func, ...acc}),
-    {} as {[key in keyof TProps]: RestyleFunction<TProps, Theme, string>},
-  );
+  const funcsMap = flattenedRestyleFunctions.reduce((acc, each) => {
+    acc[each.property] = each.func;
+    return acc;
+  }, {} as {[key in keyof TProps]: RestyleFunction<TProps, Theme, string>});
 
   // TInputProps is a superset of TProps since TProps are only the Restyle Props
   const buildStyle = (


### PR DESCRIPTION
## Description
Note: This PR improves performance

My goal here is to improve the code base, I noticed a bad practice happening in the code base and wanted to help. Also it could potentially hurt performance if this is used a lot in someone's code base.

The issue is how Javascript reduce is being used

When using reduce, you are allowed to use mutation when you just building from a new object, especially a place empty object as your initial value, this is because it is impossible to have a side effect in that case. You are simply building an object while assigning properties one by one in these examples.. However, you are creating new memory every single loop when you use the spread operator this way.

## Reviewers’ hat-rack :tophat:
This changes no behavior
- [ ] All tests still pass

